### PR TITLE
Allow plain "URL" in event handler templates.

### DIFF
--- a/lib/cylc/suite_events.py
+++ b/lib/cylc/suite_events.py
@@ -146,9 +146,9 @@ class SuiteEventHandler(object):
                 if config.cfg['meta']:
                     for key, value in config.cfg['meta'].items():
                         if key == "URL":
+                            # Back compat (pre meta section).
                             handler_data["suite_url"] = quote(value)
-                        else:
-                            handler_data[key] = quote(value)
+                        handler_data[key] = quote(value)
                 cmd = handler % (handler_data)
             except KeyError as exc:
                 message = "%s bad template: %s" % (cmd_key, exc)

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -836,9 +836,9 @@ class TaskEventsManager(object):
                 if itask.tdef.rtconfig['meta']:
                     for key, value in itask.tdef.rtconfig['meta'].items():
                         if key == "URL":
+                            # Back compat (pre meta section).
                             handler_data["task_url"] = quote(value)
-                        else:
-                            handler_data[key] = quote(value)
+                        handler_data[key] = quote(value)
 
                 cmd = handler % (handler_data)
             except KeyError as exc:


### PR DESCRIPTION
@challurip - another change for your current Pull Request branch, so that users don't have to use the old backward compatibility form of URL items in handler command line templates.  i.e. allow  `%(URL)s` or `%(suite_url)s` in suite event handlers, and `%(URL)s` or %(task_url)s` in task event handlers.  `%(suite_url)s` is still required in task event handlers, to distinguish suite and task URLs.